### PR TITLE
rollup to azurerm 3.0.1

### DIFF
--- a/ngw.tf
+++ b/ngw.tf
@@ -5,7 +5,7 @@ resource "azurerm_public_ip" "main" {
   resource_group_name = local.global_settings.resource_group_name
   allocation_method   = local.ngw_settings.public_ip_allocation_method
   sku                 = local.ngw_settings.public_ip_sku
-  availability_zone   = each.value != null ? each.value : null
+  zones               = each.value != null ? [each.value] : null
   tags                = local.tags
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,6 @@ terraform {
   required_version = ">= 1.0.0"
 
   required_providers {
-    azurerm = ">= 2.28"
+    azurerm = ">= 3.0.1"
   }
 }


### PR DESCRIPTION
upgrades module to work with azurerm 3.0.1 and later.   This contains some breaking resource attribute changes to meet this requirement due to the `zones` normalization.